### PR TITLE
ReCaptcha: CURLOPT_FOLLOWLOCATION removed [Closes #4]

### DIFF
--- a/src/ReCaptchaControl/ReCaptcha.php
+++ b/src/ReCaptchaControl/ReCaptcha.php
@@ -72,7 +72,6 @@ class ReCaptcha
 				'response' => $post[self::RESPONSE_KEY],
 			)),
 			CURLOPT_RETURNTRANSFER => TRUE,
-			CURLOPT_FOLLOWLOCATION => TRUE,
 			CURLOPT_SSL_VERIFYHOST => FALSE,
 			CURLOPT_SSL_VERIFYPEER => FALSE,
 		));


### PR DESCRIPTION
See #4 

Warning: curl_setopt_array(): CURLOPT_FOLLOWLOCATION cannot be activated when an open_basedir is set