### PR TITLE
forcing ampersand as separator in http_build_query

### DIFF
--- a/src/ReCaptchaControl/ReCaptcha.php
+++ b/src/ReCaptchaControl/ReCaptcha.php
@@ -70,7 +70,7 @@ class ReCaptcha
 				'remoteip' => $remoteIP,
 				'secret' => $this->secretKey,
 				'response' => $post[self::RESPONSE_KEY],
-			)),
+			), '', '&'),
 			CURLOPT_RETURNTRANSFER => TRUE,
 			CURLOPT_SSL_VERIFYHOST => FALSE,
 			CURLOPT_SSL_VERIFYPEER => FALSE,


### PR DESCRIPTION
Validation request require url attributes to be separated by ampersands. What happened to me was that hosting provider had changed arg_separator.output directive to something else (& amp;) so http_build_query returned attributes separated by '& amp;' what caused that validation request wasn't successful. Maybe it would be helpful to pass 3rd argument of http_build_query explicitly.